### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up .NET Core SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.x'
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up .NET Core SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '5.0.x'
 
       - name: Set up DocFx
-        uses: crazy-max/ghaction-chocolatey@v1
+        uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install docfx
       - name: Build DocFx
@@ -27,7 +27,7 @@ jobs:
         continue-on-error: false
       # Workaround for github-pages-deploy-action, which requires Ubuntu.
       - name: Upload DocFx artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: site
           path: docfx_project/_site
@@ -46,21 +46,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Download DocFx artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: site
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Deploy DocFx to versioned folder
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: docs
           folder: site
           target-folder: ${{ env.RELEASE_VERSION }}
       - name: Deploy DocFx to latest folder
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: docs
           folder: site


### PR DESCRIPTION
Obviously doesn't test the "publish" workflow, but from a read-through of the relevant documentation, nothing seems to have changed API-wise.